### PR TITLE
fix: stories that use webextension-polyfill are broken

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,5 +1,9 @@
 import "../src/app/styles/index.css";
 
+// Needed to make Storybook work with webextension-polyfill.
+if (!chrome.runtime) chrome.runtime = {};
+if (!chrome.runtime.id) chrome.runtime.id = "history-delete";
+
 export const parameters = {
   actions: { argTypesRegex: "^on[A-Z].*" },
   controls: {

--- a/src/stories/Onboard.stories.js
+++ b/src/stories/Onboard.stories.js
@@ -13,4 +13,11 @@ export const TestConnection = () => <TestConnectionScreen />;
 
 export default {
   title: "Screens/Onboard",
+  decorators: [
+    (Story) => (
+      <div className="container mx-auto">
+        <Story />
+      </div>
+    ),
+  ],
 };

--- a/src/stories/Transactions.stories.js
+++ b/src/stories/Transactions.stories.js
@@ -1,10 +1,10 @@
 import React from "react";
 import Transactions from "../app/components/Wallet/Transactions/index";
-import '../app/styles/index.css';
+import "../app/styles/index.css";
 
 export const Primary = () => <Transactions />;
 
 export default {
-  title: "Pages/Wallet/Transactions",
+  title: "Screens/Wallet/Transactions",
   component: Transactions,
 };


### PR DESCRIPTION
Onboarding screens we're not shown anymore inside Storybook because of a webextension-polyfill error: 'Error: This script should only be loaded in a browser extension.'
