### PR TITLE
Refactor currency input & collapse

### DIFF
--- a/src/app/components/Collapse.tsx
+++ b/src/app/components/Collapse.tsx
@@ -6,8 +6,10 @@ type Props = {
 };
 
 function Collapse({ isOpen = false, children }: Props) {
+  const collapseEl = useRef<HTMLDivElement>(null);
   const contentEl = useRef<HTMLDivElement>(null);
   const [childHeight, setChildHeight] = useState(0);
+  const [isAnimating, setIsAnimating] = useState(false);
 
   useEffect(() => {
     if (contentEl.current && contentEl.current.clientHeight !== childHeight) {
@@ -15,16 +17,35 @@ function Collapse({ isOpen = false, children }: Props) {
     }
   }, [isOpen, childHeight]);
 
+  useEffect(() => {
+    setIsAnimating(true);
+  }, [isOpen]);
+
+  function transitionComplete() {
+    setIsAnimating(false);
+  }
+
+  useEffect(() => {
+    if (collapseEl.current) {
+      const el = collapseEl.current;
+      el.addEventListener("transitionend", transitionComplete);
+
+      return () => {
+        el.removeEventListener("transitionend", transitionComplete);
+      };
+    }
+  }, []);
+
   return (
     <div
-      className="collapse transition-all duration-300 overflow-hidden"
+      ref={collapseEl}
+      className="collapse transition-all duration-300"
       style={{
-        maxHeight: isOpen ? `${childHeight}px` : 0,
+        height: isOpen ? `${childHeight}px` : 0,
+        overflow: isAnimating || !isOpen ? "hidden" : "visible",
       }}
     >
-      <div className="overflow-auto" ref={contentEl}>
-        {children}
-      </div>
+      <div ref={contentEl}>{children}</div>
     </div>
   );
 }

--- a/src/app/components/Form/CurrencyInput.tsx
+++ b/src/app/components/Form/CurrencyInput.tsx
@@ -1,22 +1,25 @@
 import React from "react";
 
 function CurrencyInput({
+  id,
+  name,
+  placeholder,
   onChange,
 }: React.InputHTMLAttributes<HTMLInputElement>) {
   return (
     <div className="relative rounded-md shadow-sm">
-      <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+      {/* <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
         <span className="text-gray-500 sm:text-sm">$</span>
-      </div>
+      </div> */}
       <input
         type="text"
-        name="price"
-        id="price"
-        className="focus:ring-orange-bitcoin focus:border-orange-bitcoin block w-full pl-7 pr-12 sm:text-sm border-gray-300 rounded-md"
-        placeholder="0.00"
+        name={name}
+        id={id}
+        className="focus:ring-orange-bitcoin focus:border-orange-bitcoin block w-full px-3 sm:text-sm border-gray-300 rounded-md"
+        placeholder={placeholder}
         onChange={onChange}
       />
-      <div className="absolute inset-y-0 right-0 flex items-center">
+      {/* <div className="absolute inset-y-0 right-0 flex items-center">
         <label htmlFor="currency" className="sr-only">
           Currency
         </label>
@@ -29,7 +32,7 @@ function CurrencyInput({
           <option>EUR</option>
           <option>BTC</option>
         </select>
-      </div>
+      </div> */}
     </div>
   );
 }

--- a/src/app/screens/ConfirmPayment/index.jsx
+++ b/src/app/screens/ConfirmPayment/index.jsx
@@ -90,12 +90,15 @@ class ConfirmPayment extends React.Component {
                 </p>
                 <div>
                   <label
-                    htmlFor="price"
+                    htmlFor="budget"
                     className="mb-1 block text-sm font-medium text-gray-700"
                   >
                     Budget
                   </label>
                   <CurrencyInput
+                    id="budget"
+                    name="budget"
+                    placeholder="sats"
                     onChange={(event) => {
                       this.setBudget(event.target.value);
                     }}


### PR DESCRIPTION
- CurrencyInput should only support satoshi's for now.
- (visual improvement) The collapse component was cutting of the input border. Now it will apply overflow:hidden styles only during transition.