### PR TITLE
Prevent font-scaling by Chrome (making text-base obsolete)

### DIFF
--- a/src/app/components/Navbar/NavbarLink.tsx
+++ b/src/app/components/Navbar/NavbarLink.tsx
@@ -12,7 +12,7 @@ function NavbarLink({ children, exact = false, href }: Props) {
     <NavLink
       exact={exact}
       to={href}
-      className="block text-gray-500 hover:text-gray-700 px-1 text-base font-semibold transition-color duration-200"
+      className="block text-gray-500 hover:text-gray-700 px-1 font-semibold transition-color duration-200"
       activeClassName="text-orange-bitcoin hover:text-orange-bitcoin"
     >
       {children}

--- a/src/app/components/Shared/tabs.jsx
+++ b/src/app/components/Shared/tabs.jsx
@@ -10,7 +10,7 @@ export default function Tabs({ tabs }) {
         <select
           id="tabs"
           name="tabs"
-          className="block w-full pl-3 pr-10 py-2 text-base border-gray-300 focus:outline-none focus:ring-orange-bitcoin focus:border-orange-bitcoin sm:text-sm rounded-md"
+          className="block w-full pl-3 pr-10 py-2 border-gray-300 focus:outline-none focus:ring-orange-bitcoin focus:border-orange-bitcoin sm:text-sm rounded-md"
           defaultValue={tabs.find((tab) => tab.current).name}
         >
           {tabs.map((tab) => (

--- a/src/app/components/button.tsx
+++ b/src/app/components/button.tsx
@@ -14,7 +14,7 @@ export default function Button({
   return (
     <button
       type={type}
-      className={`inline-flex justify-center items-center px-7 py-2 border border-transparent text-base font-medium rounded-md shadow-sm text-white bg-orange-bitcoin hover:bg-hover-orange-bitcoin focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-hover-orange-bitcoin ${
+      className={`inline-flex justify-center items-center px-7 py-2 border border-transparent font-medium rounded-md shadow-sm text-white bg-orange-bitcoin hover:bg-hover-orange-bitcoin focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-hover-orange-bitcoin ${
         fullWidth ? "w-full" : ""
       }`}
       onClick={onClick}

--- a/src/app/components/card.jsx
+++ b/src/app/components/card.jsx
@@ -3,9 +3,11 @@ import React from "react";
 export default function Card({ alias, satoshis, fiat, color, currency }) {
   return (
     <div className={`bg-${color} h-36 rounded-lg mt-5 pt-6`}>
-      <p className="text-base	font-normal text-white ml-6">{alias}</p>
+      <p className="font-normal text-white ml-6">{alias}</p>
       <p className="text-2xl font-medium text-white ml-6 mt-2">{satoshis}</p>
-      <p className="text-base font-normal text-white ml-6 mt-1">{fiat} {currency}</p>
+      <p className="font-normal text-white ml-6 mt-1">
+        {fiat} {currency}
+      </p>
     </div>
   );
 }

--- a/src/app/screens/Enable/index.jsx
+++ b/src/app/screens/Enable/index.jsx
@@ -53,13 +53,11 @@ function Enable(props) {
           Connect with <i>{props.origin.host}</i>
         </h3>
 
-        <p className="text-base text-gray-500 mb-4">
+        <p className="text-gray-500 mb-4">
           <strong>{props.origin.name}</strong> does not have access to your
           account.
         </p>
-        <p className="text-base text-gray-500 mb-4">
-          Do you want to grant them access?
-        </p>
+        <p className="text-gray-500 mb-4">Do you want to grant them access?</p>
 
         <div className="mt-8 mb-5">
           <Button type="primary" label="Enable" fullWidth onClick={enable} />

--- a/src/app/screens/Onboard/ConnectLND/index.jsx
+++ b/src/app/screens/Onboard/ConnectLND/index.jsx
@@ -56,25 +56,21 @@ export default function ConnectLnd() {
           <img className="mb-12" src="https://i.ibb.co/3F3mCkR/logox.png" />
         </div>
         <h1 className="text-3xl font-bold mt-4">Connect to your remote node</h1>
-        <p className="text-base text-gray-500 mt-6">
+        <p className="text-gray-500 mt-6">
           You will need to retreive the node url and an admin macaroon. Not sure
           where to find these details?
         </p>
-        <p className="text-base text-orange-bitcoin mt-2">
-          Check out this guides.
-        </p>
+        <p className="text-orange-bitcoin mt-2">Check out this guides.</p>
         <form onSubmit={handleSubmit}>
           <div className="w-4/5">
             <div className="mt-6">
-              <label className="block text-base font-medium text-gray-700">
-                Address
-              </label>
+              <label className="block font-medium text-gray-700">Address</label>
               <div>
                 <Input name="url" onChange={handleChange} required />
               </div>
             </div>
             <div className="mt-6">
-              <label className="block text-base font-medium text-gray-700">
+              <label className="block font-medium text-gray-700">
                 Macaroon
               </label>
               <div className="mt-1">

--- a/src/app/screens/Onboard/Intro/faqs.jsx
+++ b/src/app/screens/Onboard/Intro/faqs.jsx
@@ -26,7 +26,7 @@ export default function FAQs(props) {
                 </Disclosure.Button>
               </dt>
               <Disclosure.Panel as="dd" className="mt-2 pr-12">
-                <p className="text-base text-gray-500">{faq.answer}</p>
+                <p className="text-gray-500">{faq.answer}</p>
               </Disclosure.Panel>
             </>
           )}

--- a/src/app/screens/Onboard/Intro/features.jsx
+++ b/src/app/screens/Onboard/Intro/features.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-export default function Features({features}) {
+export default function Features({ features }) {
   return (
     <div className="mt-10 space-y-10 sm:space-y-0 sm:grid sm:grid-cols-2 sm:gap-x-8 sm:gap-y-10 lg:mt-0 lg:col-span-2">
       {features.map((feature) => (
@@ -13,9 +13,7 @@ export default function Features({features}) {
               {feature.name}
             </p>
           </dt>
-          <dd className="mt-2 text-base text-gray-500">
-            {feature.description}
-          </dd>
+          <dd className="mt-2 text-gray-500">{feature.description}</dd>
         </div>
       ))}
     </div>

--- a/src/app/screens/Onboard/LastStep/index.jsx
+++ b/src/app/screens/Onboard/LastStep/index.jsx
@@ -8,7 +8,7 @@ export default function LastStep() {
         <img src="https://i.ibb.co/3F3mCkR/logox.png" />
       </div>
       <h1 className="text-3xl font-bold mt-5">You’re all set 🎉</h1>
-      <p className="text-base text-gray-500 mt-6">
+      <p className="text-gray-500 mt-6">
         Awesome. Now you’ve connected your node would you like to Do you want to
         go through a tutorial?
       </p>

--- a/src/app/screens/Onboard/SetPassword/index.jsx
+++ b/src/app/screens/Onboard/SetPassword/index.jsx
@@ -42,20 +42,18 @@ export default function SetPassword() {
           <img className="mb-12" src="https://i.ibb.co/3F3mCkR/logox.png" />
         </div>
         <h1 className="text-3xl font-bold mt-4">Secure the bag!</h1>
-        <p className="text-base text-gray-500 mt-6">
+        <p className="text-gray-500 mt-6">
           You need to set a password so we can lock the wallet when it’s not
           being used. The browser is not the most secure environment and access
           to your node needs to be kept private when not in use.
         </p>
-        <p className="text-base text-orange-bitcoin mt-2">
-          Check out this guides.
-        </p>
+        <p className="text-orange-bitcoin mt-2">Check out this guides.</p>
         <form onSubmit={handleSubmit}>
           <div className="w-4/5">
             <div className="mt-6">
               <label
                 htmlFor="email"
-                className="block text-base font-medium text-gray-700"
+                className="block font-medium text-gray-700"
               >
                 Set a password
               </label>
@@ -71,7 +69,7 @@ export default function SetPassword() {
             <div className="mt-6">
               <label
                 htmlFor="email"
-                className="block text-base font-medium text-gray-700"
+                className="block font-medium text-gray-700"
               >
                 Lets confirm you typed it correct.
               </label>

--- a/src/app/screens/Onboard/TestConnection/index.jsx
+++ b/src/app/screens/Onboard/TestConnection/index.jsx
@@ -12,7 +12,7 @@ export default function TestConnection() {
         <div className="relative">
           <div className="mt-12">
             <h1 className="text-3xl font-bold mt-4">Connection success!</h1>
-            <p className="text-base text-gray-500 mt-6">
+            <p className="text-gray-500 mt-6">
               Awesome we were able to connect to your lightning node. Are these
               these correct details?
             </p>
@@ -29,13 +29,13 @@ export default function TestConnection() {
               <div className="sm:divide-y sm:divide-gray-200">
                 <div className="py-4 sm:py-5 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-6">
                   <dt className="text-lg font-semibold text-black">Channels</dt>
-                  <dd className="mt-1 text-base font-medium text-gray-900 sm:mt-0 sm:col-span-2">
+                  <dd className="mt-1 font-medium text-gray-900 sm:mt-0 sm:col-span-2">
                     3
                   </dd>
                 </div>
                 <div className="py-4 sm:py-5 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-6">
                   <dt className="text-lg font-semibold text-black">Node URL</dt>
-                  <dd className="mt-1 text-base font-medium text-gray-900 sm:mt-0 sm:col-span-2">
+                  <dd className="mt-1 font-medium text-gray-900 sm:mt-0 sm:col-span-2">
                     regtest-bob.nomadiclabs.net
                   </dd>
                 </div>

--- a/src/app/styles/index.css
+++ b/src/app/styles/index.css
@@ -19,3 +19,7 @@
   font-named-instance: 'Italic';
   src: url("./fonts/Inter-italic.var.woff2?v=3.18") format("woff2");
 }
+
+body {
+  font-size: 100%;
+}


### PR DESCRIPTION
For some reason chrome adds `font-size: 75%` to a browser extension.
This PR now makes the use of the class "text-base" redundant, as a font will be the size of 1rem by default now (as it should be).